### PR TITLE
chore(android): add missing result.success call

### DIFF
--- a/android/src/main/kotlin/com/k9i/flutter_tiktok_sdk/FlutterTiktokSdkPlugin.kt
+++ b/android/src/main/kotlin/com/k9i/flutter_tiktok_sdk/FlutterTiktokSdkPlugin.kt
@@ -50,6 +50,7 @@ class FlutterTiktokSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, P
         val clientKey = call.argument<String?>("clientKey")
         TikTokOpenApiFactory.init(TikTokOpenConfig(clientKey))
         tikTokOpenApi = TikTokOpenApiFactory.create(activity)
+        result.success(null)
       }
       "login" -> {
         val request = Authorization.Request()


### PR DESCRIPTION
The flutter side of the MethodChannel returns a Future, thus most developers would add an await. But since the result.success() method is never called the Future will never resolve and it will wait forever.

To make the implementation match the [interface](https://api.flutter.dev/flutter/services/MethodChannel/invokeMethod.html) lets just call result.success(null) when done to indicate that the method finished.

I just stumbled upon this and found that [another library had the same issue,](https://github.com/CleverTap/clevertap-flutter/issues/81) thus it was easy to find the fix.